### PR TITLE
Feature/spring secuirty/fixes

### DIFF
--- a/backend/src/main/java/org/umcs/appollo/controllers/PollController.java
+++ b/backend/src/main/java/org/umcs/appollo/controllers/PollController.java
@@ -37,14 +37,14 @@ public class PollController implements PollsApi {
     @Override
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Poll> createPoll(@Valid Poll poll) {
-        PollEntity createdPool;
+        PollEntity createdPoll;
         try{
-            createdPool = pollService.createPoll(poll);
+            createdPoll = pollService.createPoll(poll);
 
         }catch(ResponseStatusException ex){
             throw new RuntimeException(ex.getMessage());
         }
-        return ResponseEntity.ok().body(pollService.getPoll(createdPool.getId()));
+        return ResponseEntity.ok().body(pollService.getPoll(createdPoll.getId()));
     }
 
     @Override

--- a/backend/src/main/java/org/umcs/appollo/controllers/PollController.java
+++ b/backend/src/main/java/org/umcs/appollo/controllers/PollController.java
@@ -2,16 +2,20 @@ package org.umcs.appollo.controllers;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import org.umcs.appollo.api.PollsApi;
 import org.umcs.appollo.model.PollEntity;
+import org.umcs.appollo.model.UserEntity;
 import org.umcs.appollo.model.api.Answer;
 import org.umcs.appollo.model.api.Poll;
 import org.umcs.appollo.model.api.PollLabel;
 import org.umcs.appollo.services.AnswersService;
 import org.umcs.appollo.services.PollService;
+import org.umcs.appollo.services.UserService;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -21,11 +25,13 @@ import java.util.List;
 public class PollController implements PollsApi {
 
     private final PollService pollService;
+    private final UserService userService;
     private final AnswersService answersService;
 
-    public PollController(PollService pollService, AnswersService answersService) {
+    public PollController(PollService pollService, AnswersService answersService, UserService userService) {
         this.pollService = pollService;
         this.answersService = answersService;
+        this.userService = userService;
     }
 
     @Override
@@ -87,10 +93,19 @@ public class PollController implements PollsApi {
     }
 
     @Override
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<List<Answer>> submitAnswersToPollById(Integer id, @Valid List<Answer> filledPoll) {
         List<Answer> addPollAnswers;
         try {
-            addPollAnswers = answersService.addPollAnswers(id, filledPoll);
+            addPollAnswers = answersService.addPollAnswers(id, filledPoll,
+                    userService.findOne(
+                            ((User)SecurityContextHolder
+                                    .getContext()
+                                    .getAuthentication()
+                                    .getPrincipal())
+                                    .getUsername())
+                            .getId()
+            );
         } catch(ResponseStatusException ex) {
             throw new RuntimeException(ex.getMessage());
         }

--- a/backend/src/main/java/org/umcs/appollo/controllers/PollController.java
+++ b/backend/src/main/java/org/umcs/appollo/controllers/PollController.java
@@ -1,5 +1,6 @@
 package org.umcs.appollo.controllers;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -44,7 +45,7 @@ public class PollController implements PollsApi {
         }catch(ResponseStatusException ex){
             throw new RuntimeException(ex.getMessage());
         }
-        return ResponseEntity.ok().body(pollService.getPoll(createdPoll.getId()));
+        return new ResponseEntity<>(pollService.getPoll(createdPoll.getId()), HttpStatus.CREATED);
     }
 
     @Override

--- a/backend/src/main/java/org/umcs/appollo/controllers/UserController.java
+++ b/backend/src/main/java/org/umcs/appollo/controllers/UserController.java
@@ -1,4 +1,5 @@
 package org.umcs.appollo.controllers;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -61,7 +62,7 @@ public class UserController implements UsersApi {
             throw new RuntimeException(e.getMessage());
         }
 
-       return ResponseEntity.ok(result);
+        return new ResponseEntity<>(result, HttpStatus.CREATED);
     }
 
     @Override

--- a/backend/src/main/java/org/umcs/appollo/converters/UserConverter.java
+++ b/backend/src/main/java/org/umcs/appollo/converters/UserConverter.java
@@ -14,9 +14,6 @@ public class UserConverter {
             return null;
 
         User out = new User();
-        LinkedList<String> userRoles = new LinkedList<>();
-        for (RoleEntity role: userEntity.getRoles())
-            userRoles.add(role.getName());
 
         out.setId(userEntity.getId());
         out.setUsername(userEntity.getUsername());

--- a/backend/src/main/java/org/umcs/appollo/model/AnswerEntity.java
+++ b/backend/src/main/java/org/umcs/appollo/model/AnswerEntity.java
@@ -5,7 +5,7 @@ import javax.persistence.*;
 @Entity(name = "Answer")
 public class AnswerEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, updatable = false)
     private Integer id;
 

--- a/backend/src/main/java/org/umcs/appollo/model/PollEntity.java
+++ b/backend/src/main/java/org/umcs/appollo/model/PollEntity.java
@@ -6,7 +6,7 @@ import java.util.List;
 @Entity(name = "Poll")
 public class PollEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, updatable = false)
     private Integer id;
 

--- a/backend/src/main/java/org/umcs/appollo/model/QuestionEntity.java
+++ b/backend/src/main/java/org/umcs/appollo/model/QuestionEntity.java
@@ -6,7 +6,7 @@ import java.util.List;
 @Entity(name = "Question")
 public class QuestionEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, updatable = false)
     private Integer id;
 

--- a/backend/src/main/java/org/umcs/appollo/model/RoleEntity.java
+++ b/backend/src/main/java/org/umcs/appollo/model/RoleEntity.java
@@ -6,7 +6,7 @@ import java.util.Set;
 @Entity(name = "Role")
 public class RoleEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, updatable = false)
     private long id;
 

--- a/backend/src/main/java/org/umcs/appollo/model/UserEntity.java
+++ b/backend/src/main/java/org/umcs/appollo/model/UserEntity.java
@@ -13,7 +13,7 @@ public class UserEntity {
     @Column(name = "id", nullable = false, updatable = false)
     private Integer id;
 
-    @Column(name = "username", nullable = false, unique = true)
+    @Column(name = "username", nullable = false)
     private String username;
 
     @Column(name = "first_name", nullable = false)

--- a/backend/src/main/java/org/umcs/appollo/model/UserEntity.java
+++ b/backend/src/main/java/org/umcs/appollo/model/UserEntity.java
@@ -9,7 +9,7 @@ import java.util.Set;
 @Table(name = "user", uniqueConstraints = {@UniqueConstraint(columnNames = "email"), @UniqueConstraint(columnNames = "username")})
 public class UserEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, updatable = false)
     private Integer id;
 

--- a/backend/src/main/java/org/umcs/appollo/model/UserEntity.java
+++ b/backend/src/main/java/org/umcs/appollo/model/UserEntity.java
@@ -13,7 +13,7 @@ public class UserEntity {
     @Column(name = "id", nullable = false, updatable = false)
     private Integer id;
 
-    @Column(name = "username", nullable = false)
+    @Column(name = "username", nullable = false, unique = true)
     private String username;
 
     @Column(name = "first_name", nullable = false)

--- a/backend/src/main/java/org/umcs/appollo/services/AnswersService.java
+++ b/backend/src/main/java/org/umcs/appollo/services/AnswersService.java
@@ -72,6 +72,7 @@ public class AnswersService {
     // place.
     private AnswerEntity enrichAnswerWithQuestionInfo(Answer a, Integer userId) {
         AnswerEntity answer = answerConverter.FromApiToEntity(a);
+        answer.setId(null);
         Integer questionId = a.getQuestionId();
         Optional<QuestionEntity> question = questionRepository.findById(questionId);
         if (question.isEmpty()) {

--- a/backend/src/main/java/org/umcs/appollo/services/PollService.java
+++ b/backend/src/main/java/org/umcs/appollo/services/PollService.java
@@ -58,15 +58,15 @@ public class PollService {
     }
 
     public void deletePoll(Integer id) {
-        PollEntity poll = pollRepository.getById(id);
-        if (poll == null) {
+        if (!pollRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Poll with id " + id + " not found.");
         }
+        PollEntity poll = pollRepository.getById(id);
         pollRepository.delete(poll);
     }
 
     public Poll updatePoll(Integer id, Poll newPoll) {
-        if (pollRepository.getById(id) == null) {
+        if (!pollRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Poll with id " + id + " not found.");
         }
         PollEntity newPollEntity = pollConverter.FromApiToEntity(newPoll);

--- a/backend/src/main/java/org/umcs/appollo/services/PollService.java
+++ b/backend/src/main/java/org/umcs/appollo/services/PollService.java
@@ -4,12 +4,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 import org.umcs.appollo.converters.PollConverter;
+import org.umcs.appollo.converters.QuestionConverter;
 import org.umcs.appollo.model.PollEntity;
 import org.umcs.appollo.model.QuestionEntity;
 import org.umcs.appollo.model.api.Poll;
 import org.umcs.appollo.model.api.PollLabel;
+import org.umcs.appollo.model.api.Question;
 import org.umcs.appollo.repository.PollRepository;
 import org.umcs.appollo.repository.QuestionRepository;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -19,12 +23,14 @@ public class PollService {
     private final PollRepository pollRepository;
     private final PollConverter pollConverter;
     private final QuestionRepository questionRepository;
+    private final QuestionConverter questionConverter;
 
     public PollService(PollRepository pollRepository, PollConverter pollConverter,
-            QuestionRepository questionRepository) {
+            QuestionRepository questionRepository, QuestionConverter questionConverter) {
         this.pollRepository = pollRepository;
         this.pollConverter = pollConverter;
         this.questionRepository = questionRepository;
+        this.questionConverter = questionConverter;
     }
 
     public List<PollLabel> getPolls() {
@@ -49,12 +55,18 @@ public class PollService {
         PollEntity pollEntity = pollConverter.FromApiToEntity(poll);
         if (pollEntity == null)
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Poll not found");
-        for (QuestionEntity question : pollEntity.getQuestions())
-            question.setPoll(pollEntity);
+
+        pollEntity.setId(null);
+        pollEntity.setQuestions(null);
         pollEntity = pollRepository.save(pollEntity);
-        pollEntity.setQuestions(
-                questionRepository.saveAll(pollEntity.getQuestions()));
-        return pollEntity;
+        List<QuestionEntity> questionEntities = new ArrayList<>();
+        for (Question question : poll.getQuestions()) {
+            QuestionEntity questionEntity = questionConverter.FromApiToEntity(question);
+            questionEntity.setPoll(pollEntity);
+            questionEntities.add(questionEntity);
+        }
+        pollEntity.setQuestions(questionEntities);
+        return pollRepository.save(pollEntity);
     }
 
     public void deletePoll(Integer id) {

--- a/backend/src/main/java/org/umcs/appollo/services/UserService.java
+++ b/backend/src/main/java/org/umcs/appollo/services/UserService.java
@@ -8,6 +8,7 @@ public interface UserService {
     User addNewUser(User user);
     List<User> findAll();
     User findOne(int id);
+    User findOne(String username);
     User edit(int id, User data);
     void delete(int id);
 }

--- a/backend/src/main/java/org/umcs/appollo/services/UserServiceImpl.java
+++ b/backend/src/main/java/org/umcs/appollo/services/UserServiceImpl.java
@@ -58,6 +58,7 @@ public class UserServiceImpl implements UserDetailsService, UserService {
     @Override
     public User addNewUser(User user) {
         UserEntity userEntity = userConverter.FromApiToEntity(user);
+        userEntity.setId(null);
         userEntity.setPassword(bCryptPasswordEncoder.encode(user.getPassword()));
         Set<RoleEntity> roles = new HashSet<>();
         roles.add(roleService.findByName(RoleNames.ROLE_USER));

--- a/backend/src/main/java/org/umcs/appollo/services/UserServiceImpl.java
+++ b/backend/src/main/java/org/umcs/appollo/services/UserServiceImpl.java
@@ -104,14 +104,13 @@ public class UserServiceImpl implements UserDetailsService, UserService {
     @Override
     public void delete(int id) {
         UserEntity user = userRepository.getById(id);
-        if(user == null)
+        if(!userRepository.existsById(id))
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Poll with id " + id + " not found.");
         else
         {
             for (RoleEntity role : user.getRoles())
                 user.removeRole(role);
             userRepository.delete(user);
-
         }
     }
 }

--- a/backend/src/main/java/org/umcs/appollo/services/UserServiceImpl.java
+++ b/backend/src/main/java/org/umcs/appollo/services/UserServiceImpl.java
@@ -88,6 +88,15 @@ public class UserServiceImpl implements UserDetailsService, UserService {
     }
 
     @Override
+    public User findOne(String username) {
+        UserEntity target = userRepository.findByUsername(username);
+        if (target == null)
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No user of username " + username + " found.");
+
+        return userConverter.FromEntityToApi(target);
+    }
+
+    @Override
     public User edit(int id, User data) {
         UserEntity target = userRepository.getById(id);
         target.setUsername(data.getUsername());

--- a/backend/src/main/java/org/umcs/appollo/services/UserServiceImpl.java
+++ b/backend/src/main/java/org/umcs/appollo/services/UserServiceImpl.java
@@ -66,9 +66,7 @@ public class UserServiceImpl implements UserDetailsService, UserService {
         userEntity.setAnswers(new ArrayList<>());
         userEntity.setPolls(new ArrayList<>());
 
-        userRepository.save(userEntity);
-
-        user = userConverter.FromEntityToApi(userEntity);
+        user = userConverter.FromEntityToApi(userRepository.save(userEntity));
         return user;
     }
 
@@ -97,8 +95,8 @@ public class UserServiceImpl implements UserDetailsService, UserService {
         target.setEmail(data.getEmail());
         target.setFirstName(data.getFirstname());
         target.setLastName(data.getLastname());
-        userRepository.save(target);
-        return userConverter.FromEntityToApi(target);
+
+        return userConverter.FromEntityToApi(userRepository.save(target));
     }
 
     @Override

--- a/backend/src/main/resources/api.yaml
+++ b/backend/src/main/resources/api.yaml
@@ -310,7 +310,6 @@ components:
     Poll:
       type: object
       required:
-        - id
         - questions
       properties:
         id:
@@ -331,7 +330,6 @@ components:
     Question:
       type: object
       required:
-        - id
         - text
         - type
       properties:
@@ -361,7 +359,6 @@ components:
     Answer:
       type: object
       required:
-        - id
         - question_id
         - answer_json
       properties:

--- a/backend/src/test/java/org/umcs/appollo/AppolloConverterTests.java
+++ b/backend/src/test/java/org/umcs/appollo/AppolloConverterTests.java
@@ -9,14 +9,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.umcs.appollo.converters.AnswerConverter;
 import org.umcs.appollo.converters.PollConverter;
 import org.umcs.appollo.converters.QuestionConverter;
+import org.umcs.appollo.converters.UserConverter;
 import org.umcs.appollo.model.AnswerEntity;
 import org.umcs.appollo.model.PollEntity;
 import org.umcs.appollo.model.QuestionEntity;
 import org.umcs.appollo.model.UserEntity;
-import org.umcs.appollo.model.api.Answer;
-import org.umcs.appollo.model.api.Poll;
-import org.umcs.appollo.model.api.PollLabel;
-import org.umcs.appollo.model.api.Question;
+import org.umcs.appollo.model.api.*;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -29,9 +27,9 @@ public class AppolloConverterTests {
     private QuestionConverter questionConverter;
     private AnswerConverter answerConverter;
     private PollConverter pollConverter;
+    private UserConverter userConverter;
 
-    private UserEntity user1, user2;
-    private final int pollId = 0, questionId = 1, answerId = 2;
+    private final int pollId = 0, questionId = 1, answerId = 2, user1Id = 3;
 
     private PollEntity pollEntity;
     private Poll poll;
@@ -48,11 +46,20 @@ public class AppolloConverterTests {
     private Answer answer;
     private final String answerJson = gson.toJson("Blue");
 
+    private UserEntity user1Entity, user2Entity;
+    private User user1;
+    private final String username1 = "user1";
+    private final String password1 = "p1";
+    private final String email1 = "hehe@yo.com";
+    private final String firstName1 = "Man";
+    private final String lastName1 = "Spider";
+
     @Before
     public void setup() {
         questionConverter = new QuestionConverter();
         answerConverter = new AnswerConverter();
         pollConverter = new PollConverter(questionConverter);
+        userConverter = new UserConverter();
 
         answerEntity = new AnswerEntity();
         questionEntity = new QuestionEntity();
@@ -62,17 +69,43 @@ public class AppolloConverterTests {
         question = new Question();
         poll = new Poll();
 
-        user1 = new UserEntity();
-        user2 = new UserEntity();
+        // Model users
+        user1Entity = new UserEntity();
+        user1Entity.setId(user1Id);
+        user1Entity.setUsername(username1);
+        user1Entity.setPassword(password1);
+        user1Entity.setEmail(email1);
+        user1Entity.setFirstName(firstName1);
+        user1Entity.setLastName(lastName1);
+        user1 = new User();
+        user1.setId(user1Id);
+        user1.setUsername(username1);
+        user1.setPassword(password1);
+        user1.setEmail(email1);
+        user1.setFirstname(firstName1);
+        user1.setLastname(lastName1);
+
+        user2Entity = new UserEntity();
+//        user2Entity.setId(user2Id);
+//        user2Entity.setUsername(username2);
+//        user2Entity.setPassword(password2);
+//        user2Entity.setEmail(email2);
+//        user2Entity.setFirstName(firstName2);
+//        user2Entity.setLastName(lastName2);
+//        user2 = new User();
+//        user2.setId(user2Id);
+//        user2.setUsername(username2);
+//        user2.setPassword(password2);
+//        user2.setEmail(email2);
+//        user2.setFirstname(firstName2);
+//        user2.setLastname(lastName2);
 
         // Model a poll
         pollEntity.setId(pollId);
         pollEntity.setName(pollName);
-        pollEntity.setUser(user1);
+        pollEntity.setUser(user1Entity);
         poll.setId(pollId);
         poll.setName(pollName);
-        // TODO: no method?
-//        pollDetails.setUser(user1);
 
         // Model a question
         questionEntity.setId(questionId);
@@ -87,7 +120,7 @@ public class AppolloConverterTests {
 
         // Model an answer
         answerEntity.setId(answerId);
-        answerEntity.setUser(user2);
+        answerEntity.setUser(user2Entity);
         answerEntity.setAnswerJson(answerJson);
         answer.setId(answerId);
         answer.setAnswerJson(answerJson);
@@ -154,9 +187,7 @@ public class AppolloConverterTests {
         PollEntity pollEntity = pollConverter.FromApiToEntity(poll);
         Assert.assertEquals(pollEntity.getId().intValue(), pollId);
         Assert.assertEquals(pollEntity.getName(), pollName);
-//        Assert.assertEquals(pollEntity.getUser(), user1);
         Assert.assertEquals(pollEntity.getQuestions().size(), 1);
-//        Assert.assertEquals(pollEntity.getQuestions().get(0), questionEntity);
     }
 
     @Test
@@ -167,9 +198,6 @@ public class AppolloConverterTests {
         Assert.assertEquals(questionEntity.getOptions(), questionOptions);
         Assert.assertEquals(questionEntity.getText(), questionText);
         Assert.assertEquals(questionEntity.getType(), questionType);
-//        Assert.assertEquals(questionEntity.getAnswers().size(), 1);
-//        Assert.assertEquals(questionEntity.getAnswers().get(0), answerEntity);
-//        Assert.assertEquals(questionEntity.getPoll(), pollEntity);
     }
 
     @Test
@@ -177,8 +205,30 @@ public class AppolloConverterTests {
         Assert.assertNull(answerConverter.FromApiToEntity(null));
         AnswerEntity answerEntity = answerConverter.FromApiToEntity(answer);
         Assert.assertEquals(answerEntity.getId().intValue(), answerId);
-//        Assert.assertEquals(answerEntity.getQuestion(), questionEntity);
         Assert.assertEquals(answerEntity.getAnswerJson(), answerJson);
-//        Assert.assertEquals(answerEntity.getUser(), user2);
+    }
+
+    @Test
+    public void ConvertUserFromApiToEntity() {
+        Assert.assertNull(userConverter.FromApiToEntity(null));
+        UserEntity userEntity = userConverter.FromApiToEntity(user1);
+        Assert.assertEquals(userEntity.getId().intValue(), user1Id);
+        Assert.assertEquals(userEntity.getUsername(), username1);
+        Assert.assertEquals(userEntity.getPassword(), password1);
+        Assert.assertEquals(userEntity.getEmail(), email1);
+        Assert.assertEquals(userEntity.getFirstName(), firstName1);
+        Assert.assertEquals(userEntity.getLastName(), lastName1);
+    }
+
+    @Test
+    public void ConvertUserFromEntityToApi() {
+        Assert.assertNull(userConverter.FromEntityToApi(null));
+        User user = userConverter.FromEntityToApi(user1Entity);
+        Assert.assertEquals(user.getId().intValue(), user1Id);
+        Assert.assertEquals(user.getUsername(), username1);
+        Assert.assertEquals(user.getPassword(), password1);
+        Assert.assertEquals(user.getEmail(), email1);
+        Assert.assertEquals(user.getFirstname(), firstName1);
+        Assert.assertEquals(user.getLastname(), lastName1);
     }
 }


### PR DESCRIPTION
Zmiany:
- Dodawanie userów przechodzi od razu, bo wcześniej były konfilkty o ID przy 2 pierwszych próbach (zmiana generowania auto na identity)
- Zmiana sprawdzania czy encja istnieje oparta o szukanie po id zamiast porównywanie do nulla (co nie działa)
- Przypisanie userId do jego odpowiedzi, id pozyskane przez wyszukanie usera w repo po usernamie (username uzyskany z kontekstu spring security)
- Próba tworzenia nowych encji czegoś przy jednoczesnym podaniu istniejącego ID już nie updatuje encji tylko tworzy nową z nowym ID
- Fix Mateusza na wywalanie 500'tki przy tworzeniu większych polli od razu wcielony do zmiany wyżej
- Dodanie testów na user converter
- Pomniejsze poprawki
