### PR TITLE
Delete custom Table definition for Users

### DIFF
--- a/backend/src/main/java/org/umcs/appollo/model/UserEntity.java
+++ b/backend/src/main/java/org/umcs/appollo/model/UserEntity.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Set;
 
 @Entity(name = "User")
-@Table(name = "user", uniqueConstraints = {@UniqueConstraint(columnNames = "email"), @UniqueConstraint(columnNames = "username")})
 public class UserEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
For some reason postgres cannot create `Users` table. I suspect it may have something to do with those custom constraints. Temporarily i suggest to throw those out, as we dont have much time.